### PR TITLE
Added a parameter to load some modules before running the specs

### DIFF
--- a/src/main/java/org/codehaus/mojo/rspec/AbstractRspecMojo.java
+++ b/src/main/java/org/codehaus/mojo/rspec/AbstractRspecMojo.java
@@ -72,4 +72,12 @@ public abstract class AbstractRspecMojo extends AbstractMojo {
 	 * @since 1.0-beta-2
 	 */
 	protected boolean skip;
+
+	/**
+	 * A comma separated list of required modules (optional,
+	 * defaults to nothing).
+	 * 
+	 * @parameter expression=""
+	 */
+	protected String requiredModules;
 }

--- a/src/main/java/org/codehaus/mojo/rspec/RspecRunnerMojo.java
+++ b/src/main/java/org/codehaus/mojo/rspec/RspecRunnerMojo.java
@@ -62,7 +62,7 @@ public final class RspecRunnerMojo extends AbstractRspecMojo {
 		RubyRuntimeAdapter evaler = JavaEmbedUtils.newRuntimeAdapter();
 		IRubyObject o = evaler.eval(runtime, script.toString());
 		boolean result = ((RubyBoolean) JavaEmbedUtils.invokeMethod(runtime, o,
-				"run", new Object[] { sourceDirectory, reportFile() },
+				"run", new Object[] { sourceDirectory, requiredModules, reportFile() },
 				(Class<?>) RubyBoolean.class)).isTrue();
 		return result;
 	}

--- a/src/main/resources/RSpecRunner.rb
+++ b/src/main/resources/RSpecRunner.rb
@@ -1,12 +1,16 @@
 require 'rubygems'
 require 'rspec/core'
 
-def run(sourceDir, reportFile)
+def run(sourceDir, requiredMod, reportFile)
 	RSpec::Core::Runner.module_eval """
 	 	def self.autorun_with_args(args)
 			return if autorun_disabled? || installed_at_exit? || running_in_drb?
 			@installed_at_exit = true 
 			run(args, $stderr, $stdout)
 		end"""
-	RSpec::Core::Runner.autorun_with_args([sourceDir, '-f', 'html', '-o', reportFile])
+	opts = [sourceDir, '-f', 'html', '-o', reportFile]
+	if requiredMod
+		opts = ['-r'].product(requiredMod.split(',')).flatten + opts
+	end
+	RSpec::Core::Runner.autorun_with_args(opts)
 end


### PR DESCRIPTION
This parameter does the rspec -r option job. I can now write something like:

```
<configuration>
  <requiredModules>mod1,path/mod2</requiredModules>
</configuration>
```

This was simple to write. A better way to write this option in the pom (like a list of tags) may exist however.
